### PR TITLE
[#29] 이벤트 관리 API 구현

### DIFF
--- a/src/main/java/com/backend/common/dto/ResponseDto.java
+++ b/src/main/java/com/backend/common/dto/ResponseDto.java
@@ -12,7 +12,7 @@ public record ResponseDto<T>(T data) implements Serializable {
 
     public static ResponseEntity<Void> ok() {
         return ResponseEntity
-                .status(HttpStatus.CREATED)
+                .status(HttpStatus.OK)
                 .build();
     }
 

--- a/src/main/java/com/backend/domain/contract/entity/Contract.java
+++ b/src/main/java/com/backend/domain/contract/entity/Contract.java
@@ -4,6 +4,7 @@ import com.backend.domain.benefit.entity.Benefit;
 import com.backend.common.domain.BaseEntity;
 import com.backend.domain.contract.dto.UpdateBenefitRequest;
 import com.backend.domain.contract.dto.UpdateContractRequest;
+import com.backend.domain.event.entity.Event;
 import com.backend.domain.store.entity.Store;
 import com.backend.domain.university.entity.University;
 import jakarta.persistence.*;

--- a/src/main/java/com/backend/domain/contract/entity/Contract.java
+++ b/src/main/java/com/backend/domain/contract/entity/Contract.java
@@ -37,7 +37,7 @@ public class Contract extends BaseEntity {
     @OneToMany(mappedBy = "contract", cascade = CascadeType.PERSIST)
     private List<Benefit> benefits = new ArrayList<>();
 
-    @OneToMany(mappedBy = "contract")
+    @OneToMany(mappedBy = "contract", cascade = CascadeType.PERSIST)
     private List<Event> events = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/backend/domain/contract/repository/ContractRepository.java
+++ b/src/main/java/com/backend/domain/contract/repository/ContractRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ContractRepository extends JpaRepository<Contract, Long> {
@@ -60,5 +61,7 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
                                                               PageRequest page);
 
     Optional<Contract> findByUniversityAndStore(University university, Store store);
+
+    List<Contract> findAllByUniversity(University university);
 
 }

--- a/src/main/java/com/backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/backend/domain/event/controller/EventController.java
@@ -1,0 +1,30 @@
+package com.backend.domain.event.controller;
+
+import com.backend.common.dto.ResponseDto;
+import com.backend.domain.auth.dto.Login;
+import com.backend.domain.auth.dto.LoginUser;
+import com.backend.domain.event.dto.CreateEventRequest;
+import com.backend.domain.event.service.EventService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/event")
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "이벤트", description = "이벤트 관리 API")
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping
+    public ResponseEntity<Void> createEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @RequestBody CreateEventRequest request) {
+        eventService.createEvent(loginUser, request);
+        return ResponseDto.created();
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/backend/domain/event/controller/EventController.java
@@ -5,7 +5,9 @@ import com.backend.domain.auth.dto.Login;
 import com.backend.domain.auth.dto.LoginUser;
 import com.backend.domain.event.dto.*;
 import com.backend.domain.event.service.EventService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,24 +24,33 @@ public class EventController {
     private final EventService eventService;
 
     @PostMapping
+    @Operation(
+            summary = "이벤트 등록",
+            description =
+                    "<p>쿠폰과 스탬프를 등록합니다</p>" +
+                            "<p>쿠폰을 등록할 때에는 type을 COUPON으로 선택하고 startDate와 duration을 입력하지 않는다.</p>" +
+                            "<p>스탬프를 등록할 때에는 type을 STAMP 선택하고 startDate와 duration을 입력한다. discount는 입력하지 않는다.</p>")
     public ResponseEntity<Void> createEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @RequestBody CreateEventRequest request) {
         eventService.createEvent(loginUser, request);
         return ResponseDto.created();
     }
 
     @GetMapping("/coupon")
+    @Operation(summary = "쿠폰 목록 조회")
     public ResponseEntity<ReadCouponsDto> readCoupons(@Parameter(hidden = true) @Login LoginUser loginUser, @ModelAttribute ReadEventsRequest request) {
         ReadCouponsDto events = eventService.readCoupons(loginUser, request);
         return ResponseDto.ok(events);
     }
 
     @GetMapping
+    @Operation(summary = "이벤트 목록 조회")
     public ResponseEntity<ReadEventsDto> readEvents(@Parameter(hidden = true) @Login LoginUser loginUser, @ModelAttribute ReadEventsRequest request) {
         ReadEventsDto events = eventService.readEvents(loginUser, request);
         return ResponseDto.ok(events);
     }
 
     @PatchMapping
+    @Operation(summary = "이벤트 수정")
     public ResponseEntity<Void> updateEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @RequestBody UpdateEventRequest request) {
         eventService.updateEvent(loginUser, request);
         return ResponseDto.ok();
@@ -47,6 +58,7 @@ public class EventController {
 
 
     @DeleteMapping("/{eventId}")
+    @Operation(summary = "이벤트 삭제")
     public ResponseEntity<Void> deleteEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @Parameter(name = "eventId") @PathVariable Long eventId) {
         eventService.deleteEvent(loginUser, eventId);
         return ResponseDto.ok();

--- a/src/main/java/com/backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/backend/domain/event/controller/EventController.java
@@ -3,10 +3,7 @@ package com.backend.domain.event.controller;
 import com.backend.common.dto.ResponseDto;
 import com.backend.domain.auth.dto.Login;
 import com.backend.domain.auth.dto.LoginUser;
-import com.backend.domain.event.dto.CreateEventRequest;
-import com.backend.domain.event.dto.ReadCouponsDto;
-import com.backend.domain.event.dto.ReadEventsDto;
-import com.backend.domain.event.dto.ReadEventsRequest;
+import com.backend.domain.event.dto.*;
 import com.backend.domain.event.service.EventService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -41,6 +38,13 @@ public class EventController {
         ReadEventsDto events = eventService.readEvents(loginUser, request);
         return ResponseDto.ok(events);
     }
+
+    @PatchMapping
+    public ResponseEntity<Void> updateEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @RequestBody UpdateEventRequest request) {
+        eventService.updateEvent(loginUser, request);
+        return ResponseDto.ok();
+    }
+
 
     @DeleteMapping("/{eventId}")
     public ResponseEntity<Void> deleteEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @Parameter(name = "eventId") @PathVariable Long eventId) {

--- a/src/main/java/com/backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/backend/domain/event/controller/EventController.java
@@ -42,4 +42,10 @@ public class EventController {
         return ResponseDto.ok(events);
     }
 
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<Void> deleteEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @Parameter(name = "eventId") @PathVariable Long eventId) {
+        eventService.deleteEvent(loginUser, eventId);
+        return ResponseDto.ok();
+    }
+
 }

--- a/src/main/java/com/backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/backend/domain/event/controller/EventController.java
@@ -4,6 +4,9 @@ import com.backend.common.dto.ResponseDto;
 import com.backend.domain.auth.dto.Login;
 import com.backend.domain.auth.dto.LoginUser;
 import com.backend.domain.event.dto.CreateEventRequest;
+import com.backend.domain.event.dto.ReadCouponsDto;
+import com.backend.domain.event.dto.ReadEventsDto;
+import com.backend.domain.event.dto.ReadEventsRequest;
 import com.backend.domain.event.service.EventService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -25,6 +28,18 @@ public class EventController {
     public ResponseEntity<Void> createEvent(@Parameter(hidden = true) @Login LoginUser loginUser, @RequestBody CreateEventRequest request) {
         eventService.createEvent(loginUser, request);
         return ResponseDto.created();
+    }
+
+    @GetMapping("/coupon")
+    public ResponseEntity<ReadCouponsDto> readCoupons(@Parameter(hidden = true) @Login LoginUser loginUser, @ModelAttribute ReadEventsRequest request) {
+        ReadCouponsDto events = eventService.readCoupons(loginUser, request);
+        return ResponseDto.ok(events);
+    }
+
+    @GetMapping
+    public ResponseEntity<ReadEventsDto> readEvents(@Parameter(hidden = true) @Login LoginUser loginUser, @ModelAttribute ReadEventsRequest request) {
+        ReadEventsDto events = eventService.readEvents(loginUser, request);
+        return ResponseDto.ok(events);
     }
 
 }

--- a/src/main/java/com/backend/domain/event/dto/CreateEventRequest.java
+++ b/src/main/java/com/backend/domain/event/dto/CreateEventRequest.java
@@ -43,13 +43,20 @@ public class CreateEventRequest {
         Event event = Event.builder()
                 .type(type)
                 .name(name)
-                .quantity(quantity)
+                .quantity(createDiscount())
                 .discount(discount)
                 .startDate(startDate)
                 .endDate(startDate.plusDays(duration.getPlusDate()))
                 .build();
         event.addAll(createConditions());
         return event;
+    }
+
+    private int createDiscount() {
+        if (type.equals(BenefitType.STAMP)) {
+            return 0;
+        }
+        return discount;
     }
 
     private List<Condition> createConditions() {

--- a/src/main/java/com/backend/domain/event/dto/CreateEventRequest.java
+++ b/src/main/java/com/backend/domain/event/dto/CreateEventRequest.java
@@ -28,6 +28,8 @@ public class CreateEventRequest {
 
     private List<String> conditions;
 
+    private int discount;
+
     @Schema(example = "50")
     private int quantity;
 
@@ -42,6 +44,7 @@ public class CreateEventRequest {
                 .type(type)
                 .name(name)
                 .quantity(quantity)
+                .discount(discount)
                 .startDate(startDate)
                 .endDate(startDate.plusDays(duration.getPlusDate()))
                 .build();

--- a/src/main/java/com/backend/domain/event/dto/CreateEventRequest.java
+++ b/src/main/java/com/backend/domain/event/dto/CreateEventRequest.java
@@ -1,0 +1,58 @@
+package com.backend.domain.event.dto;
+
+import com.backend.domain.benefit.entity.BenefitType;
+import com.backend.domain.event.entity.Condition;
+import com.backend.domain.event.entity.Event;
+import com.backend.domain.popup.domain.EndDateType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateEventRequest {
+
+    @Schema(example = "3")
+    private Long storeId;
+
+    @Schema(example = "COUPON")
+    private BenefitType type;
+
+    @Schema(example = "5000원 할인 쿠폰")
+    private String name;
+
+    private List<String> conditions;
+
+    @Schema(example = "50")
+    private int quantity;
+
+    @Schema(example = "2023-11-22")
+    private LocalDate startDate;
+
+    @Schema(example = "일주일간")
+    private EndDateType duration;
+
+    public Event toEntity() {
+        Event event = Event.builder()
+                .type(type)
+                .name(name)
+                .quantity(quantity)
+                .startDate(startDate)
+                .endDate(startDate.plusDays(duration.getPlusDate()))
+                .build();
+        event.addAll(createConditions());
+        return event;
+    }
+
+    private List<Condition> createConditions() {
+        return conditions.stream()
+                .map(Condition::new)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/dto/ReadCouponDto.java
+++ b/src/main/java/com/backend/domain/event/dto/ReadCouponDto.java
@@ -1,0 +1,47 @@
+package com.backend.domain.event.dto;
+
+import com.backend.domain.event.entity.Condition;
+import com.backend.domain.event.entity.Event;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadCouponDto {
+
+    private Long couponStoreId;
+
+    private String couponStore;
+
+    private Long couponId;
+
+    private String couponName;
+
+    private List<String> couponCondition;
+
+    private int couponQuantity;
+
+    public static ReadCouponDto from(Event coupon) {
+        return ReadCouponDto.builder()
+                .couponStoreId(coupon.getContract().getStore().getStoreId())
+                .couponStore(coupon.getContract().getStore().getName())
+                .couponId(coupon.getEventId())
+                .couponName(coupon.getName())
+                .couponQuantity(coupon.getQuantity())
+                .couponCondition(getConditionStrings(coupon))
+                .build();
+    }
+
+    private static List<String> getConditionStrings(Event coupon) {
+        return coupon.getConditions().stream()
+                .map(Condition::getContent)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/dto/ReadCouponsDto.java
+++ b/src/main/java/com/backend/domain/event/dto/ReadCouponsDto.java
@@ -1,0 +1,41 @@
+package com.backend.domain.event.dto;
+
+import com.backend.domain.event.entity.Event;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadCouponsDto {
+
+    private List<ReadCouponDto> coupons;
+
+    private int pageNumber;
+
+    private Long totalCount;
+
+    private int totalPages;
+
+    public static ReadCouponsDto from(Page<Event> coupons) {
+        return ReadCouponsDto.builder()
+                .pageNumber(coupons.getNumber())
+                .totalCount(coupons.getTotalElements())
+                .totalPages(coupons.getTotalPages())
+                .coupons(getReadCouponDtos(coupons))
+                .build();
+    }
+
+    private static List<ReadCouponDto> getReadCouponDtos(Page<Event> coupons) {
+        return coupons.getContent().stream()
+                .map(ReadCouponDto::from)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/dto/ReadEventDto.java
+++ b/src/main/java/com/backend/domain/event/dto/ReadEventDto.java
@@ -1,0 +1,50 @@
+package com.backend.domain.event.dto;
+
+import com.backend.domain.benefit.entity.BenefitType;
+import com.backend.domain.event.entity.Condition;
+import com.backend.domain.event.entity.Event;
+import com.backend.domain.store.dto.StoreDto;
+import com.backend.domain.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadEventDto {
+
+    private StoreDto store;
+
+    private Long eventId;
+
+    private BenefitType eventType;
+
+    private String eventName;
+
+    private List<String> eventCondition;
+
+    private int eventQuantity;
+
+    public static ReadEventDto from(Event event, Store store) {
+        return ReadEventDto.builder()
+                .eventId(event.getEventId())
+                .eventType(event.getType())
+                .eventName(event.getName())
+                .eventQuantity(event.getQuantity())
+                .store(StoreDto.from(store))
+                .eventCondition(getConditionStrings(event))
+                .build();
+    }
+
+    private static List<String> getConditionStrings(Event event) {
+        return event.getConditions().stream()
+                .map(Condition::getContent)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/dto/ReadEventsDto.java
+++ b/src/main/java/com/backend/domain/event/dto/ReadEventsDto.java
@@ -1,0 +1,42 @@
+package com.backend.domain.event.dto;
+
+import com.backend.domain.event.entity.Event;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadEventsDto {
+
+    private List<ReadEventDto> events;
+
+    private int pageNumber;
+
+    private Long totalCount;
+
+    private int totalPages;
+
+    public static ReadEventsDto from(Page<Event> coupons) {
+        return ReadEventsDto.builder()
+                .pageNumber(coupons.getNumber())
+                .totalCount(coupons.getTotalElements())
+                .totalPages(coupons.getTotalPages())
+                .events(getReadEventDtos(coupons))
+                .build();
+    }
+
+    private static List<ReadEventDto> getReadEventDtos(Page<Event> events) {
+        return events.getContent().stream()
+                .map(event ->
+                        ReadEventDto.from(event, event.getContract().getStore()))
+                .toList();
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/dto/ReadEventsRequest.java
+++ b/src/main/java/com/backend/domain/event/dto/ReadEventsRequest.java
@@ -1,0 +1,35 @@
+package com.backend.domain.event.dto;
+
+import com.backend.domain.benefit.entity.BenefitType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadEventsRequest {
+
+    @Schema(example = "COUPON")
+    private BenefitType type;
+
+    @Schema(example = "40")
+    private int pageSize;
+
+    @Schema(example = "0")
+    private int pageNumber;
+
+    {
+        pageSize = 40;
+        pageNumber = 0;
+        type = BenefitType.COUPON;
+    }
+
+    @Schema(hidden = true)
+    public PageRequest getPage() {
+        return PageRequest.of(pageNumber, pageSize);
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/dto/UpdateEventRequest.java
+++ b/src/main/java/com/backend/domain/event/dto/UpdateEventRequest.java
@@ -1,0 +1,36 @@
+package com.backend.domain.event.dto;
+
+import com.backend.domain.popup.domain.EndDateType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateEventRequest {
+
+    @Schema(example = "3")
+    private Long eventId;
+
+    @Schema(example = "5000원 할인 쿠폰")
+    private String name;
+
+    private List<String> conditions;
+
+    private int discount;
+
+    @Schema(example = "50")
+    private int quantity;
+
+    @Schema(example = "2023-11-22")
+    private LocalDate startDate;
+
+    @Schema(example = "일주일간")
+    private EndDateType duration;
+
+}

--- a/src/main/java/com/backend/domain/event/entity/Condition.java
+++ b/src/main/java/com/backend/domain/event/entity/Condition.java
@@ -28,4 +28,7 @@ public class Condition {
         this.event = event;
     }
 
+    public void delete() {
+        event = null;
+    }
 }

--- a/src/main/java/com/backend/domain/event/entity/Condition.java
+++ b/src/main/java/com/backend/domain/event/entity/Condition.java
@@ -1,0 +1,31 @@
+package com.backend.domain.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "conditions")
+public class Condition {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long conditionId;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    public Condition(String content) {
+        this.content = content;
+    }
+
+    public void belong(Event event) {
+        this.event = event;
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/backend/domain/event/entity/Event.java
@@ -5,10 +5,13 @@ import com.backend.domain.benefit.entity.BenefitType;
 import com.backend.domain.contract.entity.Contract;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -18,14 +21,17 @@ public class Event extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long eventId;
 
+    private String name;
+
     @Enumerated(EnumType.STRING)
     private BenefitType type;
 
-    private int conditions;
+    @OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
+    private List<Condition> conditions = new ArrayList<>();
 
-    private int amount;
+    private int discount;
 
-    private int counts;
+    private int quantity;
 
     private LocalDate startDate;
 
@@ -35,8 +41,36 @@ public class Event extends BaseEntity {
     @JoinColumn(name = "contract_id")
     private Contract contract;
 
+    @Builder
+    public Event(BenefitType type, String name, int discount, int quantity, LocalDate startDate, LocalDate endDate, Contract contract) {
+        this.type = type;
+        this.name = name;
+        this.discount = discount;
+        this.quantity = quantity;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.contract = contract;
+    }
+
     public void add(Contract contract) {
         this.contract = contract;
+        setDate(contract);
+    }
+
+    public void add(Condition condition) {
+        this.conditions.add(condition);
+        condition.belong(this);
+    }
+
+    public void addAll(List<Condition> conditions) {
+        conditions.forEach(this::add);
+    }
+
+    public void setDate(Contract contract) {
+        if (type.equals(BenefitType.COUPON)) {
+            this.startDate = contract.getStartDate();
+            this.endDate = contract.getEndDate();
+        }
     }
 
 }

--- a/src/main/java/com/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/backend/domain/event/entity/Event.java
@@ -1,7 +1,8 @@
-package com.backend.domain.contract.entity;
+package com.backend.domain.event.entity;
 
 import com.backend.common.domain.BaseEntity;
 import com.backend.domain.benefit.entity.BenefitType;
+import com.backend.domain.contract.entity.Contract;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/backend/domain/event/entity/Event.java
@@ -73,4 +73,8 @@ public class Event extends BaseEntity {
         }
     }
 
+    public void expire() {
+        this.endDate = LocalDate.now().minusDays(1);
+    }
+
 }

--- a/src/main/java/com/backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/backend/domain/event/repository/EventRepository.java
@@ -1,7 +1,24 @@
 package com.backend.domain.event.repository;
 
+import com.backend.domain.benefit.entity.BenefitType;
+import com.backend.domain.contract.entity.Contract;
 import com.backend.domain.event.entity.Event;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @Query(
+            value = "select e" +
+                    "  from Event e" +
+                    " where e.type = :type and e.contract in :contracts and :now between e.startDate and e.endDate"
+    )
+    Page<Event> findAllByTypeAndContractIn(@Param(value = "type") BenefitType type, @Param(value = "contracts") List<Contract> contracts, @Param(value = "now") LocalDate now, PageRequest page);
+
 }

--- a/src/main/java/com/backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/backend/domain/event/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.backend.domain.event.repository;
+
+import com.backend.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/backend/domain/event/service/EventService.java
+++ b/src/main/java/com/backend/domain/event/service/EventService.java
@@ -1,0 +1,35 @@
+package com.backend.domain.event.service;
+
+import com.backend.domain.auth.dto.LoginUser;
+import com.backend.domain.contract.entity.Contract;
+import com.backend.domain.contract.repository.ContractRepository;
+import com.backend.domain.event.dto.CreateEventRequest;
+import com.backend.domain.event.entity.Event;
+import com.backend.domain.store.entity.Store;
+import com.backend.domain.store.repository.StoreRepository;
+import com.backend.domain.user.entity.User;
+import com.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EventService {
+
+    private final UserRepository userRepository;
+
+    private final StoreRepository storeRepository;
+
+    private final ContractRepository contractRepository;
+
+    public void createEvent(LoginUser loginUser, CreateEventRequest request) {
+        User user = userRepository.findByEmail(loginUser.getEmail()).orElseThrow(RuntimeException::new);
+        Store store = storeRepository.findById(request.getStoreId()).orElseThrow(RuntimeException::new);
+        Contract contract = contractRepository.findByUniversityAndStore(user.getUniversity(), store).orElseThrow(RuntimeException::new);
+        Event event = request.toEntity();
+        contract.add(event);
+    }
+
+}

--- a/src/main/java/com/backend/domain/event/service/EventService.java
+++ b/src/main/java/com/backend/domain/event/service/EventService.java
@@ -56,4 +56,17 @@ public class EventService {
         return ReadEventsDto.from(events);
     }
 
+    public void deleteEvent(LoginUser loginUser, Long eventId) {
+        User user = userRepository.findByEmail(loginUser.getEmail()).orElseThrow(RuntimeException::new);
+        Event event = eventRepository.findById(eventId).orElseThrow(RuntimeException::new);
+        validateAuthority(user, event);
+        event.expire();
+    }
+
+    public void validateAuthority(User user, Event event) {
+        if (!event.getContract().getUniversity().equals(user.getUniversity())) {
+            throw new RuntimeException();
+        }
+    }
+
 }

--- a/src/main/java/com/backend/domain/event/service/EventService.java
+++ b/src/main/java/com/backend/domain/event/service/EventService.java
@@ -3,10 +3,7 @@ package com.backend.domain.event.service;
 import com.backend.domain.auth.dto.LoginUser;
 import com.backend.domain.contract.entity.Contract;
 import com.backend.domain.contract.repository.ContractRepository;
-import com.backend.domain.event.dto.CreateEventRequest;
-import com.backend.domain.event.dto.ReadCouponsDto;
-import com.backend.domain.event.dto.ReadEventsDto;
-import com.backend.domain.event.dto.ReadEventsRequest;
+import com.backend.domain.event.dto.*;
 import com.backend.domain.event.entity.Event;
 import com.backend.domain.event.repository.EventRepository;
 import com.backend.domain.store.entity.Store;
@@ -61,6 +58,13 @@ public class EventService {
         Event event = eventRepository.findById(eventId).orElseThrow(RuntimeException::new);
         validateAuthority(user, event);
         event.expire();
+    }
+
+    public void updateEvent(LoginUser loginUser, UpdateEventRequest request) {
+        User user = userRepository.findByEmail(loginUser.getEmail()).orElseThrow(RuntimeException::new);
+        Event event = eventRepository.findById(request.getEventId()).orElseThrow(RuntimeException::new);
+        validateAuthority(user, event);
+        event.update(request);
     }
 
     public void validateAuthority(User user, Event event) {

--- a/src/main/java/com/backend/domain/event/service/EventService.java
+++ b/src/main/java/com/backend/domain/event/service/EventService.java
@@ -4,19 +4,29 @@ import com.backend.domain.auth.dto.LoginUser;
 import com.backend.domain.contract.entity.Contract;
 import com.backend.domain.contract.repository.ContractRepository;
 import com.backend.domain.event.dto.CreateEventRequest;
+import com.backend.domain.event.dto.ReadCouponsDto;
+import com.backend.domain.event.dto.ReadEventsDto;
+import com.backend.domain.event.dto.ReadEventsRequest;
 import com.backend.domain.event.entity.Event;
+import com.backend.domain.event.repository.EventRepository;
 import com.backend.domain.store.entity.Store;
 import com.backend.domain.store.repository.StoreRepository;
 import com.backend.domain.user.entity.User;
 import com.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class EventService {
+
+    private final EventRepository eventRepository;
 
     private final UserRepository userRepository;
 
@@ -30,6 +40,20 @@ public class EventService {
         Contract contract = contractRepository.findByUniversityAndStore(user.getUniversity(), store).orElseThrow(RuntimeException::new);
         Event event = request.toEntity();
         contract.add(event);
+    }
+
+    public ReadCouponsDto readCoupons(LoginUser loginUser, ReadEventsRequest request) {
+        User user = userRepository.findByEmail(loginUser.getEmail()).orElseThrow(RuntimeException::new);
+        List<Contract> contracts = contractRepository.findAllByUniversity(user.getUniversity());
+        Page<Event> coupons = eventRepository.findAllByTypeAndContractIn(request.getType(), contracts, LocalDate.now(), request.getPage());
+        return ReadCouponsDto.from(coupons);
+    }
+
+    public ReadEventsDto readEvents(LoginUser loginUser, ReadEventsRequest request) {
+        User user = userRepository.findByEmail(loginUser.getEmail()).orElseThrow(RuntimeException::new);
+        List<Contract> contracts = contractRepository.findAllByUniversity(user.getUniversity());
+        Page<Event> events = eventRepository.findAllByTypeAndContractIn(request.getType(), contracts, LocalDate.now(), request.getPage());
+        return ReadEventsDto.from(events);
     }
 
 }

--- a/src/main/java/com/backend/domain/store/dto/StoreDto.java
+++ b/src/main/java/com/backend/domain/store/dto/StoreDto.java
@@ -1,0 +1,26 @@
+package com.backend.domain.store.dto;
+
+import com.backend.domain.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreDto {
+
+    private Long storeId;
+
+    private String storeName;
+
+    public static StoreDto from(Store store) {
+        return StoreDto.builder()
+                .storeId(store.getStoreId())
+                .storeName(store.getName())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close #29 

## 📝 작업 내용
- 이벤트 등록
	- BenefitType으로 스탬프와 쿠폰을 구분하여 등록합니다.
- 이벤트 목록 조회
	- 현재 날짜와 이벤트 시작 및 끝 날짜를 비교하여 유효한 이벤트만 조회합니다.
- 이벤트 수정
- 이벤트 삭제
	- 이벤트 끝 날짜를 어제 날짜로 업데이하여 조회되지 않도록 합니다.

## 💬 리뷰 요구 사항
